### PR TITLE
fix mismatched external-node version

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ This repository contains a Docker Compose setup for running a PostgreSQL databas
 
 ### 2. External Node
 
-- **Image:** `matterlabs/external-node:2.0-v24.16.0`
+- **Image:** `matterlabs/external-node:2.0-v24.24.0-alpha`
 - **Depends on:** PostgreSQL service (ensures the service starts after PostgreSQL is healthy)
 - **Ports:**
   - `3060` (HTTP)

--- a/testnet-external-node.yml
+++ b/testnet-external-node.yml
@@ -32,7 +32,7 @@ services:
       - POSTGRES_PASSWORD=notsecurepassword
       - PGPORT=5430
   external-node:
-    image: "matterlabs/external-node:2.0-v24.24.0"
+    image: "matterlabs/external-node:2.0-v24.24.0-alpha"
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
Use [2.0-v24.24.0-alpha](https://hub.docker.com/r/matterlabs/external-node/tags?name=v24.24.0) to pull the image to fix the following pulling error.

```
➜  lens-node git:(master) docker-compose --file testnet-external-node.yml up -d
[+] Running 2/2
 ✘ external-node Error manifest for matterlabs/external-node:2.0-v24...  
 ✘ postgres Error      context canceled 
Error response from daemon: manifest for matterlabs/external-node:2.0-v24.24.0 not found: manifest unknown: manifest unknown
```